### PR TITLE
Allow url validation to timeout if unable to hit URL successfully

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,17 +1,22 @@
 from urls4irl import create_app
 from os import environ
 from dotenv import load_dotenv
-from urls4irl.config import TestingConfig
 
 load_dotenv(override=True)
 
-if environ.get('TESTING') is not None and environ.get('TESTING').lower() == 'true':
-    print("In testing")
-    app = create_app(TestingConfig, True)
-else:
-    print("Not in testing")
+if __name__ == "__main__":
+    if environ.get('PRODUCTION') is None:
+        print("Missing PRODUCTION environment variable.")
+        quit()
+
+    is_production = environ.get('PRODUCTION')
     app = create_app()
 
-if __name__ == "__main__":
-    app.run(host='0.0.0.0')
-    
+    if is_production.lower() == 'false':
+        print("Not in production.")
+        app.run(port=5000)
+    elif is_production.lower() == 'true':
+        print("In production.")
+        app.run(host='0.0.0.0')
+    else:
+        print("Invalid PRODUCTION environment variable.")

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -18,6 +18,15 @@ valid_urls = {
                                                             "flask-limiter.readthedocs.io/"]
 }
 
+invalid_urls = (
+    "w.google.com", "http://mw1.google.com/mw-earth-vectordb/kml-samples/gp/seattle/gigapxl/$[level]/r$[y]_c$[x].jpg",
+    "http://www.example.com/main.html", "/main.html", "http:\\www.example.com\\andhere.html"
+)
+
+unknown_urls = {
+    "https://www.homedepot.com/c/ah/how-to-build-a-bookshelf/9ba683603be9fa5395fab904e329862"
+}
+
 def test_valid_urls():
     """
     GIVEN valid URLs and their known final URL locations
@@ -29,10 +38,6 @@ def test_valid_urls():
         for url in urls_to_check:
             assert valid_url == url_valid.check_request_head(url)
 
-invalid_urls = (
-    "w.google.com", "http://mw1.google.com/mw-earth-vectordb/kml-samples/gp/seattle/gigapxl/$[level]/r$[y]_c$[x].jpg",
-    "http://www.example.com/main.html", "/main.html", "http:\\www.example.com\\andhere.html"
-)
 
 def test_invalid_urls():
     """
@@ -44,3 +49,12 @@ def test_invalid_urls():
         with pytest.raises(url_valid.InvalidURLError):
             url_valid.check_request_head(invalid_url)
             
+def test_unknown_urls():
+    """
+    GIVEN URLs that seeem to fail unknowingly...
+    WHEN the url validation function checks these invalid URLs
+    THEN ensure the request times out
+    """
+    for unknown_url in unknown_urls:
+        with pytest.raises(url_valid.InvalidURLError):
+            url_valid.check_request_head(unknown_url)

--- a/urls4irl/url_validation.py
+++ b/urls4irl/url_validation.py
@@ -83,7 +83,10 @@ def check_request_head(url: str) -> str:
     url = normalize_url(url)
     
     try:
-        response = requests.head(url)
+        response = requests.get(url, timeout=10)
+
+    except requests.exceptions.ReadTimeout:
+        raise InvalidURLError
     
     except requests.exceptions.ConnectionError:
         raise InvalidURLError
@@ -112,3 +115,5 @@ def check_request_head(url: str) -> str:
             # Redirect was found, provide the redirect URL
             return location
             
+if __name__ == "__main__":
+    check_request_head('https://www.homedepot.com/c/ah/how-to-build-a-bookshelf/9ba683603be9fa5395fab904e329862')


### PR DESCRIPTION
Allow url validation to timeout if unable to hit URL successfully.

Due to unknown timeout from following url:
https://www.homedepot.com/c/ah/how-to-build-a-bookshelf/9ba683603be9fa5395fab904e329862

Adds PRODUCTION enviroment variable to distinguish between production running or not.